### PR TITLE
Create 'ParsePKCS8PrivateKeyRSA' and 'ParsePKCS8PrivateKeyECDSA' to return typed versions of parsed keys

### DIFF
--- a/pkcs8.go
+++ b/pkcs8.go
@@ -109,6 +109,36 @@ type encryptedPrivateKeyInfo struct {
 	EncryptedData       []byte
 }
 
+// ParsePKCS8PrivateKeyRSA parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
+//
+// The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.
+func ParsePKCS8PrivateKeyRSA(der []byte, v ...[]byte) (*rsa.PrivateKey, error) {
+	key, err := ParsePKCS8PrivateKey(der, v...)
+	if err != nil {
+		return nil, err
+	}
+	typedKey, ok := key.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("key block is not of type RSA")
+	}
+	return typedKey, nil
+}
+
+// ParsePKCS8PrivateKeyECDSA parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
+//
+// The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.
+func ParsePKCS8PrivateKeyECDSA(der []byte, v ...[]byte) (*ecdsa.PrivateKey, error) {
+	key, err := ParsePKCS8PrivateKey(der, v...)
+	if err != nil {
+		return nil, err
+	}
+	typedKey, ok := key.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("key block is not of type ECDSA")
+	}
+	return typedKey, nil
+}
+
 // ParsePKCS8PrivateKey parses encrypted/unencrypted private keys in PKCS#8 format. To parse encrypted private keys, a password of []byte type should be provided to the function as the second parameter.
 //
 // The function can decrypt the private key encrypted with AES-256-CBC mode, and stored in PKCS #5 v2.0 format.

--- a/pkcs8_test.go
+++ b/pkcs8_test.go
@@ -120,35 +120,129 @@ wgo3AjtXevJaGgep5GsW2krw9S7dC7xG9dR33Z/a9nBnO1rKm7Htf0+986w/1vmj
 -----END ENCRYPTED PRIVATE KEY-----
 `
 
-func TestParsePKCS8PrivateKey(t *testing.T) {
+func TestParsePKCS8PrivateKeyRSA(t *testing.T) {
 	keyList := []struct {
+		name      string
 		clear     string
 		encrypted string
 	}{
-		{rsa2048, encryptedRSA2048aes},
-		{rsa2048, encryptedRSA2048des3},
-		{ec256, encryptedEC256aes},
+		{
+			name:      "encryptedRSA2048aes",
+			clear:     rsa2048,
+			encrypted: encryptedRSA2048aes,
+		},
+		{
+			name:      "encryptedRSA2048des3",
+			clear:     rsa2048,
+			encrypted: encryptedRSA2048des3,
+		},
 	}
 	for i, key := range keyList {
-		block, _ := pem.Decode([]byte(key.encrypted))
-		_, err := pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte("password"))
-		if err != nil {
-			t.Errorf("%d: ParsePKCS8PrivateKey returned: %s", i, err)
-		}
-		_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte("wrong password"))
-		if err == nil {
-			t.Errorf("%d: should have failed", i)
-		}
-		_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes)
-		if err == nil {
-			t.Errorf("%d: should have failed", i)
-		}
+		t.Run(key.name, func(t *testing.T) {
+			block, _ := pem.Decode([]byte(key.encrypted))
+			_, err := pkcs8.ParsePKCS8PrivateKeyRSA(block.Bytes, []byte("password"))
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKeyRSA returned: %s", i, err)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKeyRSA(block.Bytes, []byte("wrong password"))
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKeyRSA(block.Bytes)
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
 
-		block, _ = pem.Decode([]byte(key.clear))
-		_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			t.Errorf("%d: ParsePKCS8PrivateKey returned: %s", i, err)
-		}
+			block, _ = pem.Decode([]byte(key.clear))
+			_, err = pkcs8.ParsePKCS8PrivateKeyRSA(block.Bytes)
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKeyRSA returned: %s", i, err)
+			}
+		})
+	}
+}
+
+func TestParsePKCS8PrivateKeyECDSA(t *testing.T) {
+	keyList := []struct {
+		name      string
+		clear     string
+		encrypted string
+	}{
+		{
+			name:      "encryptedEC256aes",
+			clear:     ec256,
+			encrypted: encryptedEC256aes,
+		},
+	}
+	for i, key := range keyList {
+		t.Run(key.name, func(t *testing.T) {
+			block, _ := pem.Decode([]byte(key.encrypted))
+			_, err := pkcs8.ParsePKCS8PrivateKeyECDSA(block.Bytes, []byte("password"))
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKeyECDSA returned: %s", i, err)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKeyECDSA(block.Bytes, []byte("wrong password"))
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKeyECDSA(block.Bytes)
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
+
+			block, _ = pem.Decode([]byte(key.clear))
+			_, err = pkcs8.ParsePKCS8PrivateKeyECDSA(block.Bytes)
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKeyECDSA returned: %s", i, err)
+			}
+		})
+	}
+}
+
+func TestParsePKCS8PrivateKey(t *testing.T) {
+	keyList := []struct {
+		name      string
+		clear     string
+		encrypted string
+	}{
+		{
+			name:      "encryptedRSA2048aes",
+			clear:     rsa2048,
+			encrypted: encryptedRSA2048aes,
+		},
+		{
+			name:      "encryptedRSA2048des3",
+			clear:     rsa2048,
+			encrypted: encryptedRSA2048des3,
+		},
+		{
+			name:      "encryptedEC256aes",
+			clear:     ec256,
+			encrypted: encryptedEC256aes,
+		},
+	}
+	for i, key := range keyList {
+		t.Run(key.name, func(t *testing.T) {
+			block, _ := pem.Decode([]byte(key.encrypted))
+			_, err := pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte("password"))
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKey returned: %s", i, err)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte("wrong password"))
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
+			_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes)
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			}
+
+			block, _ = pem.Decode([]byte(key.clear))
+			_, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				t.Errorf("%d: ParsePKCS8PrivateKey returned: %s", i, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
@youmark 

I recently utilized your awesome library to handle private key encrypted certificates. I thought I'd make the usage a tiny bit easier for the next guy by taking advantage of Go's strong typing system and create versions of `ParsePKCS8PrivateKey` where the type assertion is handled internally.

Originally, I think the "problem" sits in Golang's standard library where some crypto functions like `x509.ParsePKCS8PrivateKey` return `interface{}` instead of a type. So if/when that is fixed the type assertions could go away, and we would just call the corresponding typed `x509` functions inside `ParsePKCS8PrivateKeyRSA` and `ParsePKCS8PrivateKeyECDSA`.