### PR TITLE
Allow running tests locally and on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - "1.9.x"
+  - "1.10.x"
+  - master
+
+script:
+  - go test -v ./...

--- a/pkcs8_test.go
+++ b/pkcs8_test.go
@@ -6,8 +6,9 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/pem"
-	"pkcs8"
 	"testing"
+
+	"github.com/youmark/pkcs8"
 )
 
 const rsa2048 = `-----BEGIN PRIVATE KEY-----


### PR DESCRIPTION
@youmark 

I created another pull request to create typed versions of `ParsePKCS8PrivateKey` (see https://github.com/youmark/pkcs8/pull/11) and there I had problems running the tests locally without first moving the test files into the same package as the code.

In my understand, in Golang the code and unit tests should reside in the same package. Correct me if I am wrong about this.