### PR TITLE
more accurate error message

### DIFF
--- a/pkcs8.go
+++ b/pkcs8.go
@@ -143,7 +143,7 @@ func ParsePrivateKey(der []byte, password []byte) (interface{}, KDFParameters, e
 	// Use the password provided to decrypt the private key
 	var privKey encryptedPrivateKeyInfo
 	if _, err := asn1.Unmarshal(der, &privKey); err != nil {
-		return nil, nil, errors.New("pkcs8: only PKCS #5 v2.0 supported")
+		return nil, nil, errors.New("pkcs8: failed to parse encrypted private key (make sure you passed the DER as the first parameter)")
 	}
 
 	if !privKey.EncryptionAlgorithm.Algorithm.Equal(oidPBES2) {

--- a/pkcs8_test.go
+++ b/pkcs8_test.go
@@ -343,6 +343,64 @@ func TestParsePKCS8PrivateKey(t *testing.T) {
 	}
 }
 
+func TestParsePKCS8PrivateKeyInvalidDER(t *testing.T) {
+	keyList := []struct {
+		name      string
+		encrypted string
+		password  string
+	}{
+		{
+			name:      "encryptedRSA2048aes",
+			encrypted: encryptedRSA2048aes,
+			password:  "password",
+		},
+		{
+			name:      "encryptedRSA2048des3",
+			encrypted: encryptedRSA2048des3,
+			password:  "password",
+		},
+		{
+			name:      "encryptedRSA2048scrypt",
+			encrypted: encryptedRSA2048scrypt,
+			password:  "password",
+		},
+		{
+			name:      "encryptedEC256aes",
+			encrypted: encryptedEC256aes,
+			password:  "password",
+		},
+		{
+			name:      "encryptedEC256aes128sha1",
+			encrypted: encryptedEC256aes128sha1,
+			password:  "password",
+		},
+		{
+			name:      "encryptedRFCscrypt",
+			encrypted: encryptedRFCscrypt,
+			password:  "Rabbit",
+		},
+		{
+			name:      "encryptedEC128aes",
+			encrypted: encryptedEC128aes,
+			password:  "password",
+		},
+	}
+	expectedError := "pkcs8: failed to parse encrypted private key (make sure you passed the DER as the first parameter)"
+
+	for i, key := range keyList {
+		t.Run(key.name, func(t *testing.T) {
+			_, err := pkcs8.ParsePKCS8PrivateKey([]byte(key.encrypted), []byte(key.password))
+			if err == nil {
+				t.Errorf("%d: should have failed", i)
+			} else {
+				if err.Error() != expectedError {
+					t.Errorf("Expected error \"%s\", got \"%s\"", expectedError, err.Error())
+				}
+			}
+		})
+	}
+}
+
 func TestConvertPrivateKeyToPKCS8(t *testing.T) {
 	for i, password := range [][]byte{nil, []byte("password")} {
 		var args [][]byte


### PR DESCRIPTION
Hi @youmark,

In issue #17, @Fire1nRain seemed confused by the error message "only PKCS#5 v2.0 supported". Indeed, the error occured, not because PKCS#5 v2.0 was not supported - based on the meta data, that private key seemed encrypted using PKCS#5 v2.0 - but because he passed an invalid ASN1 block - most likely, as @conradoplg mentioned, the raw PEM he read from the file - which is why asn1.Unmarshal failed.
So, I suggest this change to the error message (1) to be consistent with the error message returned by x509.ParsePKCS8PrivateKey when asn1.Unmarshal fails and (2) to help developers who inadvertently passed an invalid ASN1 and think it is a bug.

Hope that helps clarify things. Thanks for this library, very helpful.

Regards,
Philippe.