### PR TITLE
password mandatory when converting to pkcs#8

### DIFF
--- a/pkcs8.go
+++ b/pkcs8.go
@@ -297,13 +297,12 @@ func ParsePKCS8PrivateKeyECDSA(der []byte, v ...[]byte) (*ecdsa.PrivateKey, erro
 }
 
 // ConvertPrivateKeyToPKCS8 converts the private key into PKCS#8 format.
-// To encrypt the private key, the password of []byte type should be provided as the second parameter.
+// To encrypt the private key, the password of []byte type MUST be provided as the second parameter.
 //
 // The only supported key types are RSA and ECDSA (*rsa.PrivateKey or *ecdsa.PrivateKey for priv)
-func ConvertPrivateKeyToPKCS8(priv interface{}, v ...[]byte) ([]byte, error) {
-	var password []byte
-	if len(v) > 0 {
-		password = v[0]
+func ConvertPrivateKeyToPKCS8(priv interface{}, password []byte) ([]byte, error) {
+	if password == nil || len(password) == 0 {
+		return nil, errors.New("Password is required to protect the private key")
 	}
 	return MarshalPrivateKey(priv, password, nil)
 }


### PR DESCRIPTION
Hi @youmark,

As the goal of this library is to support - and promote? - the use of password-protected private key with strong encryption algorithms, I suggest you make the password parameter mandatory when converting to PKCS#8.
Those who prefer to keep their private key in plaintext can still use MarshalPrivateKey, where the password remains optional.
Also, this way, ConvertPrivateKeyToPKCS8 and MarshalPrivateKey have two different purposes.

Regards,
Philippe.