### PR TITLE
Extend tests to Go up to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,15 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ '1.17', '1.18', '1.19', '1.20', '1.21', '1.22' ]
+        go-version:
+          - '1.17'
+          - '1.18'
+          - '1.19'
+          - '1.20'
+          - '1.21'
+          - '1.22'
+          - '1.23'
+          - '1.24'
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Just add the new Go versions to the tests, to ensure they work, which they do flawlessly. :)